### PR TITLE
sanitize forbidden characters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    fiware-orion-geo (0.1.1)
+    fiware-orion-geo (0.2)
       httparty (~> 0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    httparty (0.13.5)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.3)
@@ -36,3 +36,6 @@ DEPENDENCIES
   rake
   rspec
   rspec-expectations
+
+BUNDLED WITH
+   1.10.6

--- a/lib/orion/geo/geo.rb
+++ b/lib/orion/geo/geo.rb
@@ -120,7 +120,7 @@ module Orion
     end
 
     def build_default_attribute(name, type, value)
-      { name: name, type: type, value: value }
+      { name: sanitize(name), type: sanitize(type), value: sanitize(value) }
     end
 
     def build_attributes(attr_data)
@@ -134,6 +134,30 @@ module Orion
         end
       end
       attr
+    end
+
+    FORBIDDEN_CHARS = {
+      '<' => '%3C',
+      '>' => '%3E',
+      '"' => '%22',
+      '\'' => '%27',
+      '=' => '%3D',
+      ';' => '%3B',
+      '(' => '%28',
+      ')' => '%29'
+    }.freeze
+
+    def sanitize(data)
+      case data
+      when String
+        FORBIDDEN_CHARS.inject(data) do |s, map|
+          forbidden = map[0]
+          escaped = map[1]
+          s.gsub(forbidden, escaped)
+        end
+      else
+        data
+      end
     end
 
   end

--- a/lib/orion/geo/geo.rb
+++ b/lib/orion/geo/geo.rb
@@ -155,6 +155,17 @@ module Orion
           escaped = map[1]
           s.gsub(forbidden, escaped)
         end
+      when Symbol
+        sanitize(data.to_s)
+      when Array
+        data.map { |elem| sanitize(elem) }
+      when Hash
+        data.inject({}) do |clean, kv|
+          key = kv[0]
+          value = kv[1]
+          clean[sanitize(key)] = sanitize(value)
+          clean
+        end
       else
         data
       end

--- a/spec/fiware_orion_geo_spec.rb
+++ b/spec/fiware_orion_geo_spec.rb
@@ -4,7 +4,8 @@ require 'fiware_orion_geo_spec_data'
 describe 'Endpoints Orion server' do
 
   before(:all) do
-    @sut = Orion::Geo.new('http://test02.notegraphy.com:1026', 21)
+    orion_url = ENV['ORION_URL'] || 'http://test02.notegraphy.com:1026'
+    @sut = Orion::Geo.new(orion_url, 21)
     @data = FiwareOrionGeoSpecData.new
   end
 

--- a/spec/fiware_orion_geo_spec.rb
+++ b/spec/fiware_orion_geo_spec.rb
@@ -32,8 +32,15 @@ describe 'Endpoints Orion server' do
     # http://fiware-orion.readthedocs.org/en/develop/user/forbidden_characters/index.html
     it 'should escape forbidden characters' do
       id = 'forbidden'
+      value = [
+        '<>"\'=;()',
+        {
+          "not<>valid" => "invali(d)",
+          :'not()valid_sym' => "not=good"
+        }
+      ]
       data = [
-        { type: 'attr', data: {name: 'na<m)e', type: 'stri;ng', value: '<>"\'=;()'}}
+        { type: 'attr', data: {name: 'na<m)e', type: 'Str;ang(e)Array', value: value}}
       ]
       response = @sut.create('testnotes', id, data)
       body = parse_orion_response(response.body)

--- a/spec/fiware_orion_geo_spec.rb
+++ b/spec/fiware_orion_geo_spec.rb
@@ -29,6 +29,27 @@ describe 'Endpoints Orion server' do
       expect(@context_response['statusCode']['code']).to eq(200.to_s)
     end
 
+    # http://fiware-orion.readthedocs.org/en/develop/user/forbidden_characters/index.html
+    it 'should escape forbidden characters' do
+      id = 'forbidden'
+      data = [
+        { type: 'attr', data: {name: 'na<m)e', type: 'stri;ng', value: '<>"\'=;()'}}
+      ]
+      response = @sut.create('testnotes', id, data)
+      body = parse_orion_response(response.body)
+      expect(body).not_to be nil
+      context_response = body.first
+      expect(context_response['statusCode']['code']).to eq(200.to_s)
+
+      response = @sut.get('testnotes', id)
+      context_response = parse_orion_response(response.body).first
+      expect(context_response['contextElement'].size).to eq(4)
+      expect(context_response['statusCode']['code']).to eq(200.to_s)
+      responde = @sut.delete('testnotes', id)
+      context_response = parse_orion_response(response.body).first
+      expect(context_response['statusCode']['code']).to eq(200.to_s)
+    end
+
     after(:all) do
       delete_test_notes([@id])
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,8 @@ def create_test_notes(notes_data)
         updateAction: 'APPEND'
       }.to_json
     }
-    HTTParty.post('http://test02.notegraphy.com:1026/v1/updateContext', options)
+    orion_url = ENV['ORION_URL'] || 'http://test02.notegraphy.com:1026'
+    HTTParty.post("#{orion_url}/v1/updateContext", options)
   end
 end
 
@@ -76,6 +77,7 @@ def delete_test_notes(notes_ids)
         updateAction: 'DELETE'
       }.to_json
     }
-    HTTParty.post('http://test02.notegraphy.com:1026/v1/updateContext', options)
+    orion_url = ENV['ORION_URL'] || 'http://test02.notegraphy.com:1026'
+    HTTParty.post("#{orion_url}/v1/updateContext", options)
   end
 end


### PR DESCRIPTION
Some characters are not allowed in orion, this patches escape them as required in [orion documentation](http://fiware-orion.readthedocs.org/en/develop/user/forbidden_characters/index.html)
